### PR TITLE
upgrade django-import-export. Fixes #332

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ psycopg2==2.6.1
 dataset>=0.5.6
 pytz>=2015.4
 django-crispy-forms==1.4.0
-django-import-export==0.3.1
+django-import-export==0.4.2
 django-registration-redux==1.2
 django-debug-toolbar>=1.3.2
 django-suit>=0.2.13


### PR DESCRIPTION
Error message will be shown to user. For example:

`InvalidDimensions encountred while trying to read file:`

Waiting for approval to pull request to django-import-export to shown actual name of file to user. django-import-export/django-import-export#401